### PR TITLE
Use rack.input's read or string when appropriate.

### DIFF
--- a/lib/active_admin/wysihtml5/admin/assets.rb
+++ b/lib/active_admin/wysihtml5/admin/assets.rb
@@ -58,7 +58,7 @@ ActiveAdmin.register Asset do
 
         # io.original_filename = params['qqfile']
 
-        @asset.storage = Dragonfly::TempObject.new(io.responds_to?(:string) ? io.string : io.read)
+        @asset.storage = Dragonfly::TempObject.new(io.respond_to?(:string) ? io.string : io.read)
         if @asset.save!
           render json: { success: true }.to_json
         else

--- a/lib/active_admin/wysihtml5/admin/assets.rb
+++ b/lib/active_admin/wysihtml5/admin/assets.rb
@@ -58,7 +58,7 @@ ActiveAdmin.register Asset do
 
         # io.original_filename = params['qqfile']
 
-        @asset.storage = Dragonfly::TempObject.new(io.string)
+        @asset.storage = Dragonfly::TempObject.new(io.responds_to?(:string) ? io.string : io.read)
         if @asset.save!
           render json: { success: true }.to_json
         else


### PR DESCRIPTION
Hello,

The rack spec support's read instead of string, which is causing errors with this gem when deploying with application servers like Phusion Passenger and NGINX.

While Thin uses string just fine (e.g localhost development), deploying with NGINX is giving me this error: `NoMethodError (undefined method 'string' for #<Unicorn::TeeInput` traced back to [this line](https://github.com/stefanoverna/activeadmin-wysihtml5/blob/master/lib/active_admin/wysihtml5/admin/assets.rb#L61).

The attached commits check if `string` is available and default to `read` if it's not.

References:  
-  http://rack.rubyforge.org/doc/SPEC.html
-  https://groups.google.com/forum/?fromgroups=#!topic/phusion-passenger/EYbAUYoh5qE
-  https://github.com/apotonick/roar-rails/issues/18
