### PR TITLE
Fix wysiwyg.css linking

### DIFF
--- a/app/assets/javascripts/activeadmin-wysihtml5/base.js.coffee.erb
+++ b/app/assets/javascripts/activeadmin-wysihtml5/base.js.coffee.erb
@@ -41,7 +41,7 @@
 
       editor = new wysihtml5.Editor($textarea.attr('id'), {
         toolbar: $toolbar.attr('id'),
-        stylesheets: "/assets/activeadmin-wysihtml5/wysiwyg.css",
+        stylesheets: "<%= asset_path("activeadmin-wysihtml5/wysiwyg.css") %>",
         parserRules: wysihtml5ParserRules
       })
 


### PR DESCRIPTION
There is an error in `wysiwyg.css` linking in production environment when using assets precompilation:

Currently this file is linked directly in js (https://github.com/stefanoverna/activeadmin-wysihtml5/blob/master/app/assets/javascripts/activeadmin-wysihtml5/base.js.coffee#L44). That's why it's Not Found after precompilation. File simply does not exists in a `public/` directory, but precompilled `wysiwyg-some-long-hash.css` exists!

Maybe there are some better solutions to fix this issue, but I've decided just to add `.erb` extension to `base.js.coffee` file to have an ability to use there Rails's  assets helpers.
