### PR TITLE
Update to dragonfly ~>1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ $ rake activeadmin_wysihtml5:install:migrations
 $ rake db:migrate
 ```
 
+Generate dragonfly configuration:
+
+```bash
+$ rails generate dragonfly
+````
+
 ## Usage
 This gem provides you with a custom formtastic input called `:wysihtml5` to build out an html editor.
 All you have to do is specify the `:as` option for your inputs.
@@ -68,4 +74,8 @@ end
 * `:large`: 350px;
 * `:huge`: 450px;
 * an integer representing the height of the editor;
+
+## Use s3 storage
+
+[instructions found here](https://github.com/markevans/dragonfly-s3_data_store/blob/master/README.md)
 

--- a/activeadmin-wysihtml5.gemspec
+++ b/activeadmin-wysihtml5.gemspec
@@ -14,6 +14,6 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib,vendor}/**/*"] + ["MIT-LICENSE", "README.md"]
 
   s.add_dependency "activeadmin"
-  s.add_dependency "activeadmin-dragonfly"
+  s.add_dependency "activeadmin-dragonfly", "~> 0.1"
 end
 

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -1,5 +1,6 @@
 class Asset < ActiveRecord::Base
-  image_accessor :storage
+  extend Dragonfly::Model
+  dragonfly_accessor :storage
 
   def percentage_thumb_url(size)
     width = (storage.width * size).ceil

--- a/lib/active_admin/wysihtml5/version.rb
+++ b/lib/active_admin/wysihtml5/version.rb
@@ -1,6 +1,6 @@
 module ActiveAdmin
   module Wysihtml5
-    VERSION = "1.0.0"
+    VERSION = "1.1.0"
   end
 end
 


### PR DESCRIPTION
This is a patch to support the current version of [dragonfly 1.0.7](https://github.com/markevans/dragonfly). So that the current version of [dragonfly-s3_data_store](https://github.com/markevans/dragonfly-s3_data_store) would work. I have also submitted a [pull request](https://github.com/stefanoverna/activeadmin-dragonfly/pull/10) for [activeadmin-dragonfly](https://github.com/stefanoverna/activeadmin-dragonfly)
