### PR TITLE
Fix default scale selection for multiple forms on page

### DIFF
--- a/lib/formtastic/inputs/wysihtml5_input.rb
+++ b/lib/formtastic/inputs/wysihtml5_input.rb
@@ -237,10 +237,12 @@ module Formtastic
                 <div class="input radio">
                   <div class="asset_scale_selection">
                     <label>#{I18n.t("wysihtml5.dialog.image.scale")}</label>
-                    <label class="option"><input value="full" type="radio" name="scale" checked="checked" /> 100%</label>
-                    <label class="option"><input value="three_quarters" type="radio" name="scale" /> 75%</label>
-                    <label class="option"><input value="half" type="radio" name="scale" /> 50%</label>
-                    <label class="option"><input value="one_quarter" type="radio" name="scale" /> 25%</label>
+                    <form>
+                      <label class="option"><input value="full" type="radio" name="scale" checked="checked" /> 100%</label>
+                      <label class="option"><input value="three_quarters" type="radio" name="scale" /> 75%</label>
+                      <label class="option"><input value="half" type="radio" name="scale" /> 50%</label>
+                      <label class="option"><input value="one_quarter" type="radio" name="scale" /> 25%</label>
+                    </form>
                   </div>
                 </div>
                 <div class="input select">


### PR DESCRIPTION
When multiple radio buttons of the same group (with same name in one `form` tag) have `checked` attribute then only last of them will be selected. That's why form tag around radio buttons is necessary when you have more then one wysiwyg forms on page. Without it all image adding modals on page except last one will not have selected default value for image scale.
