### PR TITLE
upgrade dragonfly to version 1.0.7

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -1,5 +1,5 @@
 class Asset < ActiveRecord::Base
-  image_accessor :storage
+  dragonfly_accessor :storage
 
   def percentage_thumb_url(size)
     width = (storage.width * size).ceil

--- a/lib/active_admin/wysihtml5/admin/assets.rb
+++ b/lib/active_admin/wysihtml5/admin/assets.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Asset do
-
+  menu false
   index as: :grid do |asset|
     link_to(image_tag(asset.storage.thumb("100x100#").url), admin_asset_path(asset))
   end


### PR DESCRIPTION
This pull request changes the dragonfly version to latest version, using dragonfly_accessor instead of image_accessor on Asset model.
